### PR TITLE
Updates and bug fixes

### DIFF
--- a/createList.py
+++ b/createList.py
@@ -150,7 +150,9 @@ def process_input_dir(inputDir, match, filelist, useCERNEOS, eosHost):
         # handle root files with same name, but actually different datasets
         # get the dataset info from the full path
         if 'amcatnloFXFX' in path and not 'amcatnloFXFX' in filename:
-          dataset+='_amcatnloFXFX'
+          dataset+='_amcatnloFXFX' 
+        if 'amcnloFXFX' in path and not 'amcnloFXFX' in filename:
+          dataset+='_amcatnloFXFX' #intentionally adding 'at' for consistancy with 'amcatnlo' tags above
         elif 'madgraphMLM' in path and not 'madgraphMLM' in filename:
           dataset+='_madgraphMLM'
         elif 'pythia8' in path and not 'pythia8' in filename:


### PR DESCRIPTION
Updated checkJobs.sh to output a list of failed jobs (named failedJobs2017.txt by default). Fixed a bug in createList.py that missed "amcnlo" naming--it now finds files with "amcatnlo" and "amcnlo" in name and appends "amcatlno" to the tree name.